### PR TITLE
Support Kaifa MA304H4D Meter

### DIFF
--- a/ams_han_decoder.pl
+++ b/ams_han_decoder.pl
@@ -149,7 +149,6 @@ sub configure_serial_port {
         'raw',          # set device to be a data channel, not an interactive terminal
         2400,           # 2400 baud rate
         'cs8',          # 8 data bits
-        '-parodd',      # even parity
         '-cstopb',      # 1 stop bit
         '-onlcr',       # don't translate newline to carriage return-newline
         '-iexten',      # disable non-POSIX special characters

--- a/ams_han_decoder.pl
+++ b/ams_han_decoder.pl
@@ -13,6 +13,9 @@
 # Tested with Aidon 6525 power meter and a PL2303-based USB-to-MBUS adapter (FC722) from AliExpress:
 # https://www.aliexpress.com/item/USB-transfer-MBUS-module-slave-module-communication-debug-alternative-TSS721/32719562958.html
 #
+# Also tested with a Kaifa MA304H4D and packom.net M-Bus Master Hat for the Raspberry Pi:
+# https://www.packom.net/m-bus-master-hat/
+#
 # NB: As mentioned on https://www.hjemmeautomasjon.no/forums/topic/2873-lesing-av-han-the-easy-way-tm-wip/
 # the USB-to-MBUS adapter with plastic casing is tested and does cut off long messages as mentioned.
 # It is not supported. For reference, here is the link to the broken product on AliExpress:

--- a/ams_han_decoder.pl
+++ b/ams_han_decoder.pl
@@ -149,6 +149,7 @@ sub configure_serial_port {
         'raw',          # set device to be a data channel, not an interactive terminal
         2400,           # 2400 baud rate
         'cs8',          # 8 data bits
+        '-parodd',      # even parity
         '-cstopb',      # 1 stop bit
         '-onlcr',       # don't translate newline to carriage return-newline
         '-iexten',      # disable non-POSIX special characters
@@ -605,7 +606,7 @@ sub decode_cosem_structure {
             );
         }
         # List 2 and list 3
-        if ( $hdlc_type == 8 or $hdlc_type == 10 or $hdlc_type == 9 ) {
+        if ( $hdlc_type == 8 or $hdlc_type == 10 or $hdlc_type == 9 or $hdlc_type == 11 ) {
             @keys = (
                 encode_obis_code(1,1,0,2,129,255), # 2
                 encode_obis_code(0,0,96,1,0,255),  # 3
@@ -627,7 +628,7 @@ sub decode_cosem_structure {
             );
         }
         # List 3 (appended)
-        if ( $hdlc_type == 10 ) {
+        if ( $hdlc_type == 10 or $hdlc_type == 11 ) {
             push @keys, (
                 encode_obis_code(0,0,1,0,0,255),    # 15
 


### PR DESCRIPTION
This pull request add support for the Kaifa MA304H4D meter, which uses hdlc_type 11.  You can see the decode from the output from a Kaifa MA304H4D meter towards the end of this blog post: https://piers.rocks/2020/04/01/reading-kaifa-ma304-meter.html