### PR TITLE
Add ability to specify custom port

### DIFF
--- a/ams_han_decoder.pl
+++ b/ams_han_decoder.pl
@@ -163,7 +163,7 @@ sub get_mqtt {
               : '';
     return unless $class;
     require_module($class);
-    my $mqtt = $class->new( $url->host );
+    my $mqtt = $class->new( $url->host . ':' . $url->port );
     $mqtt->login( split /:/, $url->userinfo ) if $url->userinfo;
     return $mqtt;
 }


### PR DESCRIPTION
Add ability to specify custom port when defining url to MQTT server. I.e. foo.bar.com:1111